### PR TITLE
Allow passing of image_repo location via DIEM_IMAGE_REPO env. var

### DIFF
--- a/docker/build-push-local.sh
+++ b/docker/build-push-local.sh
@@ -2,13 +2,13 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 set -e
-REPO=853397791086.dkr.ecr.us-west-2.amazonaws.com
+DIEM_IMAGE_REPO=${DIEM_IMAGE_REPO:-853397791086.dkr.ecr.us-west-2.amazonaws.com}
 
 aws ecr get-login-password \
     --region us-west-2 \
     | docker login \
     --username AWS \
-    --password-stdin "$REPO"
+    --password-stdin "$DIEM_IMAGE_REPO"
 
 BUILD_PROJECTS=(validator cluster-test init safety-rules)
 
@@ -18,7 +18,7 @@ echo "[$(date)] Using tag $TAG"
 for (( i=0; i < ${#BUILD_PROJECTS[@]}; i++ ));
 do
    PROJECT=${BUILD_PROJECTS[$i]}
-   export DIEM_BUILD_TAG="$REPO/diem_${PROJECT/-/_}:$TAG"
+   export DIEM_BUILD_TAG="$DIEM_IMAGE_REPO/diem_${PROJECT/-/_}:$TAG"
    DOCKER_BUILDER="$PROJECT"
    echo "[$(date)] Building $PROJECT via $DOCKER_BUILDER"
    "./docker/${DOCKER_BUILDER}/build.sh" --incremental

--- a/docker/cluster-test-util/build-and-push.sh
+++ b/docker/cluster-test-util/build-and-push.sh
@@ -4,8 +4,9 @@
 set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
+DIEM_IMAGE_REPO=${DIEM_IMAGE_REPO:-853397791086.dkr.ecr.us-west-2.amazonaws.com}
 
 cd $DIR
 
-docker build . --tag 853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest
-docker push 853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest
+docker build . --tag $DIEM_IMAGE_REPO/cluster-test-util:latest
+docker push $DIEM_IMAGE_REPO/cluster-test-util:latest

--- a/network/memsocket/src/lib.rs
+++ b/network/memsocket/src/lib.rs
@@ -64,7 +64,7 @@ impl Drop for MemoryListener {
     fn drop(&mut self) {
         let mut switchboard = (&*SWITCHBOARD).lock();
         // Remove the Sending side of the channel in the switchboard when
-        // MemoryListener is dropped
+        // MemoryListener is dropped.
         switchboard.0.remove(&self.port);
     }
 }

--- a/scripts/cluster_test_pod_template.yaml
+++ b/scripts/cluster_test_pod_template.yaml
@@ -15,7 +15,7 @@ spec:
     effect: "NoSchedule"
   containers:
   - name: main
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/cluster_test:{cluster_test_image_tag}
+    image: {image_repo}/diem/cluster_test:{cluster_test_image_tag}
     imagePullPolicy: Always
     env: [{env_variables}]
     command: [timeout, "{timeout_secs}", cluster-test, --deploy={image_tag} {extra_args}]

--- a/scripts/ct-k8s-status.sh
+++ b/scripts/ct-k8s-status.sh
@@ -6,14 +6,14 @@
 set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+DIEM_EKS_ARN_BASE=${DIEM_EKS_ARN_BASE:-arn:aws:eks:us-west-2:853397791086:cluster}
 source "${DIR}/ct.vars"
 
 for ((i = 0; i < ${K8S_POOL_SIZE}; i++)); do
   ws="ct-${i}"
   echo "Workspace: $ws"
   echo "Cluster test pods:"
-  context="arn:aws:eks:us-west-2:853397791086:cluster/${ws}-k8s-testnet"
+  context="${DIEM_EKS_ARN_BASE}/${ws}-k8s-testnet"
   kubectl get pods --context="${context}" -l app=cluster-test --sort-by=.status.startTime
   echo
 done

--- a/scripts/cti
+++ b/scripts/cti
@@ -16,7 +16,10 @@ EXIT_CODE=0
 # Default timeout is 45 mins
 TIMEOUT_SECS=2700
 
-K8S_CONTEXT_PATTERN='arn:aws:eks:us-west-2:853397791086:cluster/CLUSTERNAME-k8s-testnet'
+DIEM_IMAGE_REPO=${DIEM_IMAGE_REPO:-853397791086.dkr.ecr.us-west-2.amazonaws.com}
+DIEM_EKS_ARN_BASE=${DIEM_EKS_ARN_BASE:-arn:aws:eks:us-west-2:853397791086:cluster}
+
+K8S_CONTEXT_PATTERN="${DIEM_EKS_ARN_BASE}/CLUSTERNAME-k8s-testnet"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -251,6 +254,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 sed -e "s/{pod_name}/${pod_name}/g" \
     -e "s/{image_tag}/${VALIDATOR_TAG}/g" \
     -e "s/{timeout_secs}/${TIMEOUT_SECS}/g" \
+    -e "s/{image_repo}/${DIEM_IMAGE_REPO}/g" \
     -e "s/{cluster_test_image_tag}/${CLUSTER_TEST_TAG}/g" \
     -e "s^{env_variables}^${retval_join_env_vars}^g" \
     -e "s+{extra_args}+${retval_join_args}+g" \

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -21,6 +21,7 @@ use crate::{cluster_swarm::ClusterSwarm, instance::Instance};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 use crate::instance::{
+    cluster_test_utils_image, image_repo,
     ApplicationConfig::{Fullnode, Validator, Vault, LSR},
     InstanceConfig,
 };
@@ -166,6 +167,7 @@ impl ClusterSwarmKube {
             pod_name = pod_name,
             image_tag = image_tag,
             node_name = node_name,
+            image_repo = &image_repo(),
         );
         let pod_spec = get_spec_instance_from_template(pod_yaml)?;
 
@@ -180,6 +182,7 @@ impl ClusterSwarmKube {
             include_str!(VAULT_SPEC_TEMPLATE!()),
             validator_index = validator_index,
             node_name = node_name,
+            image_repo = &image_repo(),
         );
         let pod_spec = get_spec_instance_from_template(pod_yaml)?;
 
@@ -205,6 +208,7 @@ impl ClusterSwarmKube {
             pod_name = pod_name,
             image_tag = image_tag,
             node_name = node_name,
+            image_repo = &image_repo(),
         );
         get_spec_instance_from_template(pod_yaml)
     }
@@ -421,7 +425,7 @@ impl ClusterSwarmKube {
                     include_str!(JOB_TEMPLATE!()),
                     name = &job_name,
                     label = "remove-network-effects",
-                    image = "853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest",
+                    image = &cluster_test_utils_image(),
                     node_name = node.name,
                     command = "tc qdisc delete dev eth0 root || true",
                     back_off_limit = back_off_limit,
@@ -674,7 +678,7 @@ impl ClusterSwarmKube {
     ) -> Result<()> {
         self.run(
             k8s_node,
-            "853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest",
+            &cluster_test_utils_image(),
             command.as_ref(),
             job_name,
         )

--- a/testsuite/cluster-test/src/cluster_swarm/templates/diem_node_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/templates/diem_node_spec_template.yaml
@@ -17,14 +17,14 @@ spec:
   nodeName: "{node_name}"
   containers:
   - name: fluent-bit
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
+    image: {image_repo}/fluent-bit:1.3.9
     imagePullPolicy: IfNotPresent
     command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/diem/data/fluent-bit/fluent-bit.conf"]
     volumeMounts:
     - mountPath: /opt/diem/data
       name: data
   - name: debug
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/validator:{image_tag}
+    image: {image_repo}/diem/validator:{image_tag}
     imagePullPolicy: Always
     volumeMounts:
       - mountPath: /opt/diem/data
@@ -38,7 +38,7 @@ spec:
         set -x;
         while true; do sleep 10; done
   - name: main
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/validator:{image_tag}
+    image: {image_repo}/diem/validator:{image_tag}
     imagePullPolicy: Always
     resources:
       requests:

--- a/testsuite/cluster-test/src/cluster_swarm/templates/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/templates/lsr_spec_template.yaml
@@ -15,14 +15,14 @@ spec:
   nodeName: "{node_name}"
   containers:
     - name: fluent-bit
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
+      image: {image_repo}/fluent-bit:1.3.9
       imagePullPolicy: IfNotPresent
       command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/diem/data/fluent-bit/fluent-bit.conf"]
       volumeMounts:
       - mountPath: /opt/diem/data
         name: diem-data
     - name: main
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/validator_tcb:{image_tag}
+      image: {image_repo}/diem/validator_tcb:{image_tag}
       imagePullPolicy: Always
       command: ["/opt/diem/bin/safety-rules", "/opt/diem/etc/node.yaml"]
       ports:

--- a/testsuite/cluster-test/src/cluster_swarm/templates/vault_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/templates/vault_spec_template.yaml
@@ -25,7 +25,7 @@ spec:
       securityContext:
         capabilities:
           add: ["IPC_LOCK"]
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/vault:1.4.0
+      image: {image_repo}/vault:1.4.0
       imagePullPolicy: IfNotPresent
       command:
       args:
@@ -96,7 +96,7 @@ spec:
       securityContext:
         capabilities:
           add: ["IPC_LOCK"]
-      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/vault:1.4.0
+      image: {image_repo}/vault:1.4.0
       imagePullPolicy: IfNotPresent
       command:
         - "sh"


### PR DESCRIPTION
Allow passing of image_repo location via DIEM_IMAGE_REPO env. var

TODO: test this with new dadev BEFORE submitting to Diem

For Devnet migration to Diem ( [see HERE](https://docs.google.com/document/d/1IZw7dMOdKP8bIOb-jeysdhymLEsbU97IS5Zn6gemWrk/edit)  cluster-test needs to be able to fetch images from  `DiemAssociation-owned` AWS Container Registry, and CI needs to be able to publish there, .

This PR enables pointing to the correct ECR (and EKS)  by setting DIEM_IMAGE_REPO and DIEM_EKS_ARN_BASE environment vars .

If these vars are not set, the behavior **is not supposed to change**

yes

- modify a comment in widely used file (a period in memsocket/src/lib.rs comment) to to force container rebuild.
- CI with cluster-test on existing AWS account is expected to pass

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)